### PR TITLE
Remote Type filtering on file open

### DIFF
--- a/BrewShop/src/main/java/com/brew/brewshop/fragments/RecipeListFragment.java
+++ b/BrewShop/src/main/java/com/brew/brewshop/fragments/RecipeListFragment.java
@@ -7,6 +7,7 @@ import android.content.ContentUris;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
@@ -371,6 +372,11 @@ public class RecipeListFragment extends Fragment implements ViewClickListener,
                     }
 
                     if (type == null) {
+                        AlertDialog.Builder alertDialog =
+                                new AlertDialog.Builder(this.getActivity());
+                        alertDialog.setMessage(R.string.no_recipe_type)
+                                .setTitle(R.string.open);
+                        alertDialog.create().show();
                         return;
                     }
                     recipeStream =
@@ -387,6 +393,14 @@ public class RecipeListFragment extends Fragment implements ViewClickListener,
                         mStorage.createRecipe(recipe);
                     }
                     mRecipeView.drawRecipeList();
+
+                    AlertDialog.Builder alertDialog =
+                            new AlertDialog.Builder(this.getActivity());
+                    alertDialog.setMessage(String.format(
+                            getActivity().getResources().getString(
+                                    R.string.opened_recipes), recipes.length))
+                            .setTitle(R.string.open);
+                    alertDialog.create().show();
 
                     if (recipes.length == 1) {
                         showRecipe(recipes[0]);

--- a/BrewShop/src/main/res/values/strings.xml
+++ b/BrewShop/src/main/res/values/strings.xml
@@ -102,4 +102,7 @@
         <item>@string/whirlpool</item>
         <item>@string/dry_hop</item>
     </string-array>
+
+    <string name="no_recipe_type">No Recipe Type Detected</string>
+    <string name="opened_recipes">Opened %d Recipes</string>
 </resources>


### PR DESCRIPTION
Turns out that the Emulator emulates things according to spec, but the file manager on Lollipop doesn't respect the mime type correctly. This change will show all files, but there's no way to filter by file extension, the MimeType is the only supported way
