### PR TITLE
Fixes #49: Division by zero when batch volume is set to 0

### DIFF
--- a/BrewShop/src/main/java/com/brew/brewshop/fragments/RecipeStatsFragment.java
+++ b/BrewShop/src/main/java/com/brew/brewshop/fragments/RecipeStatsFragment.java
@@ -159,7 +159,10 @@ public class RecipeStatsFragment extends Fragment implements AdapterView.OnItemS
             name = getActivity().getResources().getString(R.string.unnamed_recipe);
         }
         mRecipe.setName(name);
-        mRecipe.setBatchVolume(mConverter.toGallons(mBatchVolume.getText()));
+        double mBatchVolumeGallons = mConverter.toGallons(mBatchVolume.getText());
+        if (mBatchVolumeGallons > 0) {
+            mRecipe.setBatchVolume(mBatchVolumeGallons);
+        }
         mRecipe.setBoilVolume(mConverter.toGallons(mBoilVolume.getText()));
         mRecipe.setBoilTime(Util.toDouble(mBoilTime.getText()));
 


### PR DESCRIPTION
The batch volume will only be updated when editing the recipe if the value
specified is > 0.